### PR TITLE
Update first-project.md: cargo description

### DIFF
--- a/src/presentations/part-1/includes/1-foundation/first-project.md
+++ b/src/presentations/part-1/includes/1-foundation/first-project.md
@@ -10,8 +10,7 @@
 cargo new hello-world
 ```
 
-Cargo is the build tool for Rust. It includes a package manager, commands for
-initiating libraries/CLI etc.
+Cargo is the Rust package manager. Cargo downloads your Rust package’s dependencies, compiles your packages, makes distributable packages, and uploads them to crates.io, the Rust community’s package registry.
 
 ```bash
 cd hello-world

--- a/src/presentations/part-1/includes/1-foundation/first-project.md
+++ b/src/presentations/part-1/includes/1-foundation/first-project.md
@@ -10,7 +10,7 @@
 cargo new hello-world
 ```
 
-Cargo is the Rust package manager. Cargo downloads your Rust package’s dependencies, compiles your packages, makes distributable packages, and uploads them to crates.io, the Rust community’s package registry.
+Cargo is the Rust package manager. Cargo downloads your Rust package’s dependencies, compiles your packages, makes distributable packages, and uploads them to [crates.io](https://crates.io), the Rust community’s package registry.
 
 ```bash
 cd hello-world


### PR DESCRIPTION
I think for the tutorial, we want to avoid directly mention rustc. Using the cargo's description from it documentation is more accurate.